### PR TITLE
Grammar Page + Admin Grammar Page

### DIFF
--- a/lakota_ed_api/lib/lakota_ed_api/grammar.ex
+++ b/lakota_ed_api/lib/lakota_ed_api/grammar.ex
@@ -1,0 +1,104 @@
+defmodule LakotaEdApi.Grammar do
+  @moduledoc """
+  The Grammar context.
+  """
+
+  import Ecto.Query, warn: false
+  alias LakotaEdApi.Repo
+
+  alias LakotaEdApi.Grammar.Grammar
+
+  @doc """
+  Returns the list of grammar.
+
+  ## Examples
+
+      iex> list_grammar()
+      [%Grammar{}, ...]
+
+  """
+  def list_grammar do
+    Repo.all(Grammar)
+  end
+
+  @doc """
+  Gets a single post.
+
+  Raises `Ecto.NoResultsError` if the Grammar does not exist.
+
+  ## Examples
+
+      iex> get_grammar!(123)
+      %Grammar{}
+
+      iex> get_grammar!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_grammar!(id), do: Repo.get!(Grammar, id)
+
+  @doc """
+  Creates a post.
+
+  ## Examples
+
+      iex> create_grammar(%{field: value})
+      {:ok, %Grammar{}}
+
+      iex> create_grammar(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_grammar(attrs \\ %{}) do
+    %Grammar{}
+    |> Grammar.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a post.
+
+  ## Examples
+
+      iex> update_grammar(post, %{field: new_value})
+      {:ok, %Grammar{}}
+
+      iex> update_grammar(post, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_grammar(%Grammar{} = post, attrs) do
+    post
+    |> Grammar.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a post.
+
+  ## Examples
+
+      iex> delete_grammar(post)
+      {:ok, %Grammar{}}
+
+      iex> delete_grammar(post)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_grammar(%Grammar{} = post) do
+    Repo.delete(post)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking post changes.
+
+  ## Examples
+
+      iex> change_grammar(post)
+      %Ecto.Changeset{data: %Grammar{}}
+
+  """
+  def change_grammar(%Grammar{} = post, attrs \\ %{}) do
+    Grammar.changeset(post, attrs)
+  end
+end

--- a/lakota_ed_api/lib/lakota_ed_api/grammar/grammar.ex
+++ b/lakota_ed_api/lib/lakota_ed_api/grammar/grammar.ex
@@ -1,0 +1,17 @@
+defmodule LakotaEdApi.Grammar.Grammar do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "grammar" do
+    field :grammar, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(grammar, attrs) do
+    grammar
+    |> cast(attrs, [:grammar])
+    |> validate_required([:grammar])
+  end
+end

--- a/lakota_ed_api/lib/lakota_ed_api_web/controllers/grammar_controller.ex
+++ b/lakota_ed_api/lib/lakota_ed_api_web/controllers/grammar_controller.ex
@@ -1,0 +1,43 @@
+defmodule LakotaEdApiWeb.GrammarController do
+  use LakotaEdApiWeb, :controller
+
+  alias LakotaEdApi.Grammar
+  alias LakotaEdApi.Grammar.Grammar, as: GrammarUnit
+
+  action_fallback LakotaEdApiWeb.FallbackController
+
+  def index(conn, _params) do
+    grammar = Grammar.list_grammar()
+    render(conn, "index.json", grammar: grammar)
+  end
+
+  def create(conn, %{"grammar" => grammar_params}) do
+    with {:ok, %GrammarUnit{} = grammar} <- Grammar.create_grammar(grammar_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.grammar_path(conn, :show, grammar))
+      |> render("show.json", grammar: grammar)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    grammar = Grammar.get_grammar!(id)
+    render(conn, "show.json", grammar: grammar)
+  end
+
+  def update(conn, %{"id" => id, "grammar" => grammar_params}) do
+    grammar = Grammar.get_grammar!(id)
+
+    with {:ok, %GrammarUnit{} = grammar} <- Grammar.update_grammar(grammar, grammar_params) do
+      render(conn, "show.json", grammar: grammar)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    grammar = Grammar.get_grammar!(id)
+
+    with {:ok, %GrammarUnit{}} <- Grammar.delete_grammar(grammar) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lakota_ed_api/lib/lakota_ed_api_web/router.ex
+++ b/lakota_ed_api/lib/lakota_ed_api_web/router.ex
@@ -32,5 +32,6 @@ defmodule LakotaEdApiWeb.Router do
     pipe_through :secure_api
     resources "/post", PostController, only: [:create, :update, :delete]
     resources "/lessons", LessonController, except: [:new, :edit]
+    resources "/grammar", GrammarController, except: [:new, :edit]
   end
 end

--- a/lakota_ed_api/lib/lakota_ed_api_web/views/grammar_view.ex
+++ b/lakota_ed_api/lib/lakota_ed_api_web/views/grammar_view.ex
@@ -1,0 +1,17 @@
+defmodule LakotaEdApiWeb.GrammarView do
+  use LakotaEdApiWeb, :view
+  alias LakotaEdApiWeb.GrammarView
+
+  def render("index.json", %{grammar: grammar}) do
+    %{data: render_many(grammar, GrammarView, "grammar.json")}
+  end
+
+  def render("show.json", %{grammar: grammar}) do
+    %{data: render_one(grammar, GrammarView, "grammar.json")}
+  end
+
+  def render("grammar.json", %{grammar: grammar}) do
+    %{id: grammar.id,
+      grammar: grammar.grammar}
+  end
+end

--- a/lakota_ed_api/priv/repo/migrations/20200921225540_create_grammar.exs
+++ b/lakota_ed_api/priv/repo/migrations/20200921225540_create_grammar.exs
@@ -1,0 +1,12 @@
+defmodule LakotaEdApi.Repo.Migrations.CreateGrammar do
+  use Ecto.Migration
+
+  def change do
+    create table(:grammar) do
+      add :grammar, :string
+
+      timestamps()
+    end
+
+  end
+end

--- a/lakota_ed_api/test/lakota_ed_api/grammar_test.exs
+++ b/lakota_ed_api/test/lakota_ed_api/grammar_test.exs
@@ -1,0 +1,64 @@
+defmodule LakotaEdApi.GrammarTest do
+  use LakotaEdApi.DataCase
+
+  alias LakotaEdApi.Grammar
+
+  describe "grammar" do
+    alias LakotaEdApi.Grammar.Post
+
+    @valid_attrs %{grammar: "some grammar"}
+    @update_attrs %{grammar: "some updated grammar"}
+    @invalid_attrs %{grammar: nil}
+
+    def post_fixture(attrs \\ %{}) do
+      {:ok, post} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Grammar.create_post()
+
+      post
+    end
+
+    test "list_grammar/0 returns all grammar" do
+      post = post_fixture()
+      assert Grammar.list_grammar() == [post]
+    end
+
+    test "get_post!/1 returns the post with given id" do
+      post = post_fixture()
+      assert Grammar.get_post!(post.id) == post
+    end
+
+    test "create_post/1 with valid data creates a post" do
+      assert {:ok, %Post{} = post} = Grammar.create_post(@valid_attrs)
+      assert post.grammar == "some grammar"
+    end
+
+    test "create_post/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Grammar.create_post(@invalid_attrs)
+    end
+
+    test "update_post/2 with valid data updates the post" do
+      post = post_fixture()
+      assert {:ok, %Post{} = post} = Grammar.update_post(post, @update_attrs)
+      assert post.grammar == "some updated grammar"
+    end
+
+    test "update_post/2 with invalid data returns error changeset" do
+      post = post_fixture()
+      assert {:error, %Ecto.Changeset{}} = Grammar.update_post(post, @invalid_attrs)
+      assert post == Grammar.get_post!(post.id)
+    end
+
+    test "delete_post/1 deletes the post" do
+      post = post_fixture()
+      assert {:ok, %Post{}} = Grammar.delete_post(post)
+      assert_raise Ecto.NoResultsError, fn -> Grammar.get_post!(post.id) end
+    end
+
+    test "change_post/1 returns a post changeset" do
+      post = post_fixture()
+      assert %Ecto.Changeset{} = Grammar.change_post(post)
+    end
+  end
+end

--- a/src/components/Admin/AdminGrammar/AdminGrammar.component.tsx
+++ b/src/components/Admin/AdminGrammar/AdminGrammar.component.tsx
@@ -1,0 +1,92 @@
+import React, { ChangeEvent, FC, useCallback, useEffect } from 'react';
+import { connect } from 'react-redux';
+import {AdminGrammarPropsAndActions, mapDispatchToProps, mapStateToProps} from './AdminGrammar.types';
+
+const AdminGrammar: FC<AdminGrammarPropsAndActions> = (props) => {
+    const {
+        jwt,
+        getCategories,
+        categories,
+        grammar,
+        getGrammar,
+        addGrammar,
+        deleteGrammar,
+        postsLoading,
+        setPostLoading,
+    } = props;
+
+    const fetchData = useCallback(async () => {
+        setPostLoading(true);
+        await getGrammar();
+
+        await getCategories();
+        setPostLoading(false);
+    }, [getCategories, getGrammar, setPostLoading]);
+
+    useEffect(() => {
+        fetchData();
+    }, [fetchData]);
+
+    return (
+        <div>
+            <h3 className="title is-3">Grammar:</h3>
+            <div className="tags">
+                {postsLoading && (
+                    <progress className="progress is-small is-info" max="100">
+                        50%
+                    </progress>
+                )}
+                {!postsLoading &&
+                    grammar.map((g, i) => (
+                        <span key={i} className="tag is-info">
+                            {g.grammar}
+                            <button
+                                onClick={async () =>
+                                    await deleteGrammar(g.id, jwt)
+                                }
+                                className="delete is-small"
+                            />
+                        </span>
+                    ))}
+            </div>
+
+            <hr />
+
+            <div className="control">
+                {postsLoading && (
+                    <progress className="progress is-small is-info" max="100">
+                        50%
+                    </progress>
+                )}
+                {!postsLoading && (
+                    <div className="select">
+                        <select
+                            onChange={async (
+                                event: ChangeEvent<HTMLSelectElement>
+                            ) => {
+                                if (
+                                    event.target.value !== 'Add a Grammar' &&
+                                    grammar.filter(
+                                        (g) => g.grammar === event.target.value
+                                    ).length === 0
+                                ) {
+                                    await addGrammar(event.target.value, jwt);
+                                }
+                            }}
+                        >
+                            <option>Add a Grammar</option>
+                            {categories.map((c, index) => (
+                                <option key={index}>{c}</option>
+                            ))}
+                        </select>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(AdminGrammar);

--- a/src/components/Admin/AdminGrammar/AdminGrammar.types.ts
+++ b/src/components/Admin/AdminGrammar/AdminGrammar.types.ts
@@ -1,0 +1,57 @@
+import {RootState} from "../../../redux/store";
+import {ThunkDispatch} from "redux-thunk";
+import {
+    backendAddGrammar,
+    backendDeleteGrammar,
+    backendGetCategories,
+    backendGetGrammar
+} from "../../../redux/Posts/Posts.reducer";
+import {setPostLoading} from "../../../redux/Posts/Posts.action";
+
+interface AdminGrammarProps {
+    grammar: { id: number; grammar: string }[];
+    categories: string[];
+    jwt: string;
+    postsLoading: boolean;
+}
+
+interface AdminGrammarActions {
+    getGrammar: () => void;
+    getCategories: () => void;
+    addGrammar: (grammar: string, jwt: string) => void;
+    deleteGrammar: (grammarId: number, jwt: string) => void;
+    setPostLoading: (loading: boolean) => void;
+}
+
+export type AdminGrammarPropsAndActions = AdminGrammarProps & AdminGrammarActions;
+
+export const mapStateToProps = (state: RootState): AdminGrammarProps => {
+    return {
+        grammar: state.postState.grammar,
+        categories: state.postState.categories
+            ? state.postState.categories
+            : [],
+        jwt: state.adminState.jwt,
+        postsLoading: state.postState.loadingPosts,
+    };
+};
+
+export const mapDispatchToProps = (
+    dispatch: ThunkDispatch<{}, {}, any>
+): AdminGrammarActions => {
+    return {
+        getGrammar: async () => {
+            await dispatch(backendGetGrammar());
+        },
+        getCategories: async () => {
+            await dispatch(backendGetCategories());
+        },
+        addGrammar: async (grammar: string, jwt: string) => {
+            await dispatch(backendAddGrammar(grammar, jwt));
+        },
+        deleteGrammar: async (grammarId: number, jwt: string) => {
+            await dispatch(backendDeleteGrammar(grammarId, jwt));
+        },
+        setPostLoading: (loading: boolean) => dispatch(setPostLoading(loading)),
+    };
+};

--- a/src/components/Admin/AdminGrammar/index.ts
+++ b/src/components/Admin/AdminGrammar/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AdminGrammar.component';

--- a/src/components/Admin/AdminHome/AdminHome.component.tsx
+++ b/src/components/Admin/AdminHome/AdminHome.component.tsx
@@ -38,6 +38,9 @@ const AdminHome: FC<AdminHomePropsWithActions> = (props) => {
                 <Link to={'/admin/lessons'} className="button is-primary">
                     Change Lessons
                 </Link>
+                <Link to={'/admin/grammar'} className="button is-primary">
+                    Change Grammar
+                </Link>
             </div>
             <hr />
             {posts.map((p: Post, i: number) => (

--- a/src/components/Admin/index.ts
+++ b/src/components/Admin/index.ts
@@ -1,5 +1,6 @@
 export {default as AdminHome} from './AdminHome';
 export {default as AdminLessons} from './AdminLessons';
+export {default as AdminGrammar} from './AdminGrammar';
 export {default as AdminLogin} from './AdminLogin';
 export {default as AdminPostCreate} from './AdminPostCreate'
 export {default as AdminPostEdit} from './AdminPostEdit'

--- a/src/components/App/App.component.tsx
+++ b/src/components/App/App.component.tsx
@@ -17,11 +17,13 @@ import FilteredPostsView from 'components/FilteredPostsView';
 import {
     AdminHome,
     AdminLessons,
+    AdminGrammar,
     AdminLogin,
     AdminPostCreate,
     AdminPostEdit,
 } from 'components/Admin';
 import ScrollToTop from 'components/ScrollToTop';
+import Grammar from "../Grammar";
 
 export const App: FC = () => {
     return (
@@ -38,6 +40,7 @@ export const App: FC = () => {
                             <Route path="/" exact component={Home} />
                             <Route path="/about" exact component={About} />
                             <Route path="/lessons" exact component={Lessons} />
+                            <Route path="/grammar" exact component={Grammar} />
                             <Route path="/faq" exact component={FAQ} />
                             <Route
                                 path="/post/:postId"
@@ -73,6 +76,11 @@ export const App: FC = () => {
                                 path="/admin/lessons"
                                 exact
                                 component={AdminLessons}
+                            />
+                            <Route
+                                path="/admin/grammar"
+                                exact
+                                component={AdminGrammar}
                             />
                             <Redirect from="/admin" to="/admin/login" />
                         </Switch>

--- a/src/components/Grammar/Grammar.component.tsx
+++ b/src/components/Grammar/Grammar.component.tsx
@@ -1,0 +1,131 @@
+import React, { FC, Fragment, useCallback, useEffect, useState } from 'react';
+import { connect } from 'react-redux';
+import { PostCard } from 'components/PostCard/PostCard.component';
+import {
+    GrammarPropsAndActions,
+    mapDispatchToProps,
+    mapStateToProps,
+} from './Grammar.types';
+
+const Grammar: FC<GrammarPropsAndActions> = (props) => {
+    const {
+        clearPosts,
+        posts,
+        getGrammar,
+        getPostsForGrammar,
+        grammar,
+        postsLoading,
+        setPostLoading,
+    } = props;
+
+    const [selectedGrammar, setSelectedGrammar] = useState<string>();
+    const [currentPage, setCurrentPage] = useState(1);
+
+    // Retrieve all grammar
+    const fetchData = useCallback(async () => {
+        setPostLoading(true);
+        clearPosts();
+
+        const grammar: { id: number; grammar: string }[] = await getGrammar();
+        if (grammar.length > 0) {
+            setSelectedGrammar(grammar[0].grammar);
+        }
+
+        setPostLoading(false);
+    }, [clearPosts, getGrammar, setPostLoading]);
+
+    // On start, retrieve grammar
+    useEffect(() => {
+        fetchData();
+    }, [fetchData]);
+
+    // Whenever changing the grammar, reset the page number to 1
+    useEffect(() => {
+        setCurrentPage(1)
+    }, [selectedGrammar])
+
+    // Update posts when paginating or changing the grammar
+    useEffect(() => {
+        const getPostForSelectedGrammar = async (grammar: string) => {
+            clearPosts();
+            await getPostsForGrammar(grammar, currentPage);
+        };
+        selectedGrammar && getPostForSelectedGrammar(selectedGrammar);
+    }, [currentPage, clearPosts, getPostsForGrammar, selectedGrammar]);
+
+    return (
+        <div className="container">
+            <h1 className="title">Grammar</h1>
+
+            {/*Toggle Grammar Tabs*/}
+            <div className="tabs is-toggle">
+                <ul>
+                    {!postsLoading &&
+                        grammar.map((grammar, i) => (
+                            <li
+                                className={
+                                    selectedGrammar === grammar.grammar
+                                        ? 'is-active'
+                                        : undefined
+                                }
+                                key={i}
+                                onClick={() => {
+                                    setSelectedGrammar(grammar.grammar);
+                                }}
+                            >
+                                {/*TODO: Bulma is current not accessible, specifically for usages of <a />*/}
+                                {/* being used just for convenience, breaking the required contract for accessibility*/}
+                                <a>
+                                    <span>{grammar.grammar}</span>
+                                </a>
+                            </li>
+                        ))}
+                </ul>
+            </div>
+
+            <hr />
+            {postsLoading && (
+                <progress className="progress is-small is-info" max="100">
+                    50%
+                </progress>
+            )}
+            {!postsLoading &&
+                grammar.map((grammar, i) => (
+                    <Fragment key={i}>
+                        {posts
+                            .filter((p) => p.categories.includes(grammar.grammar))
+                            .map((p, i) => (
+                                <div key={i}>
+                                    <PostCard post={p} showPreviewOnly />
+                                </div>
+                            ))}
+                    </Fragment>
+                ))}
+
+            <button
+                className="button is-info pagination-button"
+                disabled={currentPage === 1}
+                onClick={() => {
+                    if (currentPage > 1) {
+                        setCurrentPage(currentPage - 1);
+                    }
+                }}
+            >
+                Previous Page
+            </button>
+            <button
+                className="button is-info pagination-button"
+                disabled={posts.length === 0 || posts.length < 5}
+                onClick={() => {
+                    if (posts.length !== 0) {
+                        setCurrentPage(currentPage + 1);
+                    }
+                }}
+            >
+                Next Page
+            </button>
+        </div>
+    );
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Grammar);

--- a/src/components/Grammar/Grammar.types.ts
+++ b/src/components/Grammar/Grammar.types.ts
@@ -1,0 +1,50 @@
+import {
+    backendGetGrammar,
+    backendGetPostsByFilters,
+    Post
+} from "../../redux/Posts/Posts.reducer";
+import {RouteComponentProps} from "react-router";
+import {RootState} from "../../redux/store";
+import {ThunkDispatch} from "redux-thunk";
+import {clearPosts, setPostLoading} from "../../redux/Posts/Posts.action";
+
+export interface GrammarProps {
+    posts: Post[];
+    grammar: { id: number; grammar: string }[];
+    postsLoading: boolean;
+}
+
+export interface GrammarActions {
+    getPostsForGrammar: (grammar: string, pageNumber: number) => any;
+    clearPosts: () => void;
+    getGrammar: () => any;
+    setPostLoading: (loading: boolean) => void;
+}
+
+export type GrammarPropsAndActions = GrammarProps &
+    GrammarActions &
+    RouteComponentProps;
+
+export const mapStateToProps = (state: RootState): GrammarProps => ({
+    posts: state.postState.posts,
+    grammar: state.postState.grammar,
+    postsLoading: state.postState.loadingPosts,
+});
+
+export const mapDispatchToProps = (
+    dispatch: ThunkDispatch<{}, {}, any>
+): GrammarActions => {
+    return {
+        getPostsForGrammar: async (grammar: string, pageNumber: number) => {
+            return await dispatch(backendGetPostsByFilters(
+                pageNumber,
+                [grammar]
+            ));
+        },
+        clearPosts: () => dispatch(clearPosts()),
+        getGrammar: async () => {
+            return await dispatch(backendGetGrammar());
+        },
+        setPostLoading: (loading: boolean) => dispatch(setPostLoading(loading)),
+    };
+};

--- a/src/components/Grammar/index.ts
+++ b/src/components/Grammar/index.ts
@@ -1,0 +1,1 @@
+export {default} from './Grammar.component'

--- a/src/components/Navbar/Navbar.component.tsx
+++ b/src/components/Navbar/Navbar.component.tsx
@@ -62,6 +62,14 @@ export const NavBar: FC = () => {
                     </Link>
 
                     <Link
+                        to="/grammar"
+                        className="link navbar-item-hover"
+                        onClick={() => setShowHamburger(false)}
+                    >
+                        <div className="navbar-item">Grammar</div>
+                    </Link>
+
+                    <Link
                         to="/FAQ"
                         className="link navbar-item-hover"
                         onClick={() => setShowHamburger(false)}

--- a/src/redux/Posts/Posts.action.ts
+++ b/src/redux/Posts/Posts.action.ts
@@ -78,6 +78,21 @@ export interface SetPostLoading {
     payload: boolean;
 }
 
+export interface SetGrammar {
+    type: 'SET_GRAMMAR';
+    payload: { id: number; grammar: string }[];
+}
+
+export interface AddGrammar {
+    type: 'ADD_GRAMMAR';
+    payload: { id: number; grammar: string };
+}
+
+export interface DeleteGrammar {
+    type: 'DELETE_GRAMMAR';
+    payload: number;
+}
+
 export type PostActionTypes =
     | GetPosts
     | SetPosts
@@ -93,7 +108,10 @@ export type PostActionTypes =
     | SetLessons
     | AddLesson
     | DeleteLesson
-    | SetPostLoading;
+    | SetPostLoading
+    | SetGrammar
+    | AddGrammar
+    | DeleteGrammar;
 
 export const getPosts = (): PostActionTypes => {
     return {
@@ -179,6 +197,32 @@ export const deleteLesson = (lessonId: number): PostActionTypes => {
     return {
         type: 'DELETE_LESSON',
         payload: lessonId,
+    };
+};
+
+export const setGrammar = (
+    grammar: { id: number; grammar: string }[]
+): PostActionTypes => {
+    return {
+        type: 'SET_GRAMMAR',
+        payload: grammar,
+    };
+};
+
+export const addGrammar = (grammar: {
+    id: number;
+    grammar: string;
+}): PostActionTypes => {
+    return {
+        type: 'ADD_GRAMMAR',
+        payload: grammar,
+    };
+};
+
+export const deleteGrammar = (grammarId: number): PostActionTypes => {
+    return {
+        type: 'DELETE_GRAMMAR',
+        payload: grammarId,
     };
 };
 

--- a/src/redux/Posts/Posts.reducer.ts
+++ b/src/redux/Posts/Posts.reducer.ts
@@ -10,7 +10,7 @@ import {
     setTags,
     setUpdatingPostLoading,
     setWordOfTheDayPosts,
-    deleteLesson,
+    deleteLesson, setGrammar, addGrammar, deleteGrammar,
 } from './Posts.action';
 import axios, { AxiosResponse } from 'axios';
 import { AnyAction, Dispatch } from 'redux';
@@ -41,6 +41,7 @@ export interface PostState {
     updatingPostLoading: boolean;
     currentPost?: Post;
     lessons: { id: number; lesson: string }[];
+    grammar: { id: number; grammar: string }[];
     categories?: string[];
     tags?: string[];
     wordOfTheDayPosts?: Post[];
@@ -51,6 +52,7 @@ export const initialPostState: PostState = {
     posts: [],
     updatingPostLoading: false,
     lessons: [],
+    grammar: [],
     loadingPosts: false,
 };
 
@@ -148,6 +150,78 @@ export const backendDeleteLesson = (
     };
 };
 
+export const backendGetGrammar = (): ThunkAction<
+    Promise<any>,
+    RootState,
+    {},
+    AnyAction
+    > => {
+    return async (dispatch: Dispatch) => {
+        return axios
+            .get(`${apiUrl}/grammar`)
+            .then((res: any) => {
+                dispatch(setGrammar(res.data.data));
+                return Promise.resolve(res.data.data);
+            })
+            .catch((err) => {
+                console.error(err);
+                return Promise.reject(err);
+            });
+    };
+};
+
+export const backendAddGrammar = (
+    grammar: string,
+    jwt: string
+): ThunkAction<Promise<any>, RootState, {}, AnyAction> => {
+    return async (dispatch: Dispatch) => {
+        axios
+            .post(
+                `${apiUrl}/grammar`,
+                {
+                    grammar: {
+                        grammar: grammar,
+                    },
+                },
+                {
+                    headers: {
+                        Authorization: `Bearer ${jwt}`,
+                    },
+                }
+            )
+            .then((res: AxiosResponse) => {
+                dispatch(addGrammar(res.data.data));
+                Promise.resolve(res.data);
+            })
+            .catch((err) => {
+                console.error(err);
+                Promise.reject(err);
+            });
+    };
+};
+
+export const backendDeleteGrammar = (
+    grammarId: number,
+    jwt: string
+): ThunkAction<Promise<any>, RootState, {}, AnyAction> => {
+    return async (dispatch: Dispatch) => {
+        axios
+            .delete(`${apiUrl}/grammar/${grammarId}`, {
+                headers: {
+                    Authorization: `Bearer ${jwt}`,
+                },
+            })
+            .then((res: AxiosResponse) => {
+                dispatch(deleteGrammar(grammarId));
+                Promise.resolve(res.data);
+            })
+            .catch((err) => {
+                console.error(err);
+                Promise.reject(err);
+            });
+    };
+};
+
 export const backendGetCategories = (): ThunkAction<
     Promise<any>,
     RootState,
@@ -188,7 +262,7 @@ export const backendGetTags = (): ThunkAction<
     };
 };
 
-export const backendGetPostsByLessons = (
+export const backendGetPostsByCategories = (
     lessons: string[]
 ): ThunkAction<Promise<any>, RootState, {}, AnyAction> => {
     return async (dispatch: Dispatch) => {
@@ -395,6 +469,28 @@ export const postReducer = (
             return {
                 ...state,
                 lessons: newLessons,
+            };
+        }
+        case 'SET_GRAMMAR': {
+            return {
+                ...state,
+                grammar: action.payload,
+            };
+        }
+        case 'ADD_GRAMMAR': {
+            return {
+                ...state,
+                grammar: [...state.grammar, action.payload],
+            };
+        }
+        case 'DELETE_GRAMMAR': {
+            let newGrammar = state.grammar.filter(
+                (g) => g.id !== action.payload
+            );
+
+            return {
+                ...state,
+                grammar: newGrammar,
             };
         }
         case 'SET_CATEGORIES': {


### PR DESCRIPTION
Adds a grammar page and admin grammar page.

This also includes the API changes necessary to have another table for assigning posts with a "grammar" designation, which is simply a 1 column table with `grammar` being equal to a string, which matches with a known category. In other words, the admin user allocates categories under the grammar designation, and those categories show up on the grammar page (just like Lessons)