### PR TITLE
[Bugfix] Fixes issue with URL parsing

### DIFF
--- a/src/components/FilteredPostsView/FilteredPostsView.component.tsx
+++ b/src/components/FilteredPostsView/FilteredPostsView.component.tsx
@@ -164,8 +164,8 @@ export const FilteredPostsView: FC<FilteredPostsViewPropsAndActions> = (
             }
         }
 
-        return searchQuery
-    }, [selectedTagFilters, selectedCategoryFilters])
+        return searchQuery;
+    }, [selectedTagFilters, selectedCategoryFilters]);
 
     const onNextPage = useCallback(() => {
         if (posts.length !== 0) {

--- a/src/components/Grammar/Grammar.component.tsx
+++ b/src/components/Grammar/Grammar.component.tsx
@@ -114,7 +114,7 @@ const Grammar: FC<GrammarPropsAndActions> = (props) => {
 
     // Updates selected grammar from URL whenever a change is occurred
     useEffect(() => {
-        grammarFromUrl && setSelectedGrammar(grammarFromUrl);
+        grammarFromUrl && setSelectedGrammar(decodeURI(grammarFromUrl));
     }, [grammarFromUrl]);
 
     // Updates selected grammar from URL whenever a change is occurred

--- a/src/components/Lessons/Lessons.component.tsx
+++ b/src/components/Lessons/Lessons.component.tsx
@@ -114,7 +114,7 @@ const Lessons: FC<LessonsPropsAndActions> = (props) => {
 
     // Updates selected lesson from URL whenever a change is occurred
     useEffect(() => {
-        lessonFromUrl && setSelectedLesson(lessonFromUrl);
+        lessonFromUrl && setSelectedLesson(decodeURI(lessonFromUrl));
     }, [lessonFromUrl]);
 
     // Updates selected lesson from URL whenever a change is occurred

--- a/src/components/Podcasts/Podcasts.component.tsx
+++ b/src/components/Podcasts/Podcasts.component.tsx
@@ -114,7 +114,7 @@ const Podcasts: FC<PodcastsPropsAndActions> = (props) => {
 
     // Updates selected podcast from URL whenever a change is occurred
     useEffect(() => {
-        podcastFromUrl && setSelectedPodcast(podcastFromUrl);
+        podcastFromUrl && setSelectedPodcast(decodeURI(podcastFromUrl));
     }, [podcastFromUrl]);
 
     // Updates selected podcast from URL whenever a change is occurred

--- a/src/components/Vocabulary/Vocabulary.component.tsx
+++ b/src/components/Vocabulary/Vocabulary.component.tsx
@@ -114,7 +114,7 @@ const Vocabulary: FC<VocabularyPropsAndActions> = (props) => {
 
     // Updates selected vocab from URL whenever a change is occurred
     useEffect(() => {
-        vocabFromUrl && setSelectedVocab(vocabFromUrl);
+        vocabFromUrl && setSelectedVocab(decodeURI(vocabFromUrl));
     }, [vocabFromUrl]);
 
     // Updates selected vocab from URL whenever a change is occurred


### PR DESCRIPTION
Fixes a bug that occurs when navigating to a filtered post page (e.g. https://lakotalanguagelearning.com/grammar?category=Verbs&page=1), navigating to a post, then navigating backwards; this resulted in an incorrect parsing of the parameters from the URL.